### PR TITLE
Add ignoreCache option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.0.3] - 2019-05-28
+
+### Added
+
+- useQuery now accepts an optional third argument. For now, the only available option is `ignoreCache`. Which is set to false by default.
+
 ## [0.0.2] - 2019-05-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -75,13 +75,15 @@ export default Root;
 
 ### `useQuery`
 
-Signature: `(query: Query, variables: Variables) => QueryValues`
+Signature: `(query: Query, variables: Variables, options: Options) => QueryValues`
 
 [Query](#query)
 
 [Variables](#variables)
 
 [QueryValues](#queryvalues)
+
+[Options](#options)
 
 ### `Query`
 
@@ -97,4 +99,12 @@ The variables to be passed to the [Query](#query). When updated, it will re-run 
 loading: Boolean
 error?: Error
 data?: Response
+```
+
+### `Options`
+
+```js
+{
+  ignoreCache: boolean; // default: false
+}
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/react-hooks-api",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "React hooks for the Teamleader API",
   "main": "./lib/bundle.cjs.js",
   "module": "./lib/bundle.esm.js",

--- a/src/useQuery/useQuery.spec.tsx
+++ b/src/useQuery/useQuery.spec.tsx
@@ -178,4 +178,27 @@ describe('useQuery', () => {
     expect(result.current.loading).toEqual(false);
     expect(result.current.data).toEqual(['data', 'more data']);
   });
+
+  it('should not dispatch a redux action when the ignore cache options is passed', async () => {
+    const QUERY = () => ({
+      domain: 'users',
+      action: 'list',
+    });
+
+    const store = configureStore([])({ queries: {} });
+
+    const { result, waitForNextUpdate, rerender, unmount } = renderHook(
+      () => useQuery(QUERY, {}, { ignoreCache: true }),
+      {
+        wrapper: StoreWrapper(store),
+      },
+    );
+
+    await waitForNextUpdate();
+
+    expect(store.getActions()).toEqual([]);
+
+    // @TODO we should probably also test the actual state here, but redux-mock-store is
+    // purely meant for testing actions
+  });
 });

--- a/src/useQuery/useQuery.spec.tsx
+++ b/src/useQuery/useQuery.spec.tsx
@@ -179,7 +179,7 @@ describe('useQuery', () => {
     expect(result.current.data).toEqual(['data', 'more data']);
   });
 
-  it('should ignore the store when the ignoreCache option is padded', async () => {
+  it('should ignore the store when the ignoreCache option is passed', async () => {
     const QUERY = () => ({
       domain: 'users',
       action: 'list',

--- a/src/useQuery/useQuery.spec.tsx
+++ b/src/useQuery/useQuery.spec.tsx
@@ -179,26 +179,22 @@ describe('useQuery', () => {
     expect(result.current.data).toEqual(['data', 'more data']);
   });
 
-  it('should not dispatch a redux action when the ignore cache option is passed', async () => {
+  it('should ignore the store when the ignoreCache option is padded', async () => {
     const QUERY = () => ({
       domain: 'users',
       action: 'list',
     });
 
-    const store = configureStore([])({ queries: {} });
+    const storeKey = generateQueryCacheKey(QUERY());
 
-    const { result, waitForNextUpdate, rerender, unmount } = renderHook(
-      () => useQuery(QUERY, {}, { ignoreCache: true }),
-      {
-        wrapper: StoreWrapper(store),
-      },
-    );
+    const store = configureStore([])({ queries: { [storeKey]: 'cachedData' } });
+
+    const { result, waitForNextUpdate } = renderHook(() => useQuery(QUERY, {}, { ignoreCache: true }), {
+      wrapper: StoreWrapper(store),
+    });
 
     await waitForNextUpdate();
 
-    expect(store.getActions()).toEqual([]);
-
-    // @TODO we should probably also test the actual state here, but redux-mock-store is
-    // purely meant for testing actions
+    expect(result.current.data).toEqual('data');
   });
 });

--- a/src/useQuery/useQuery.spec.tsx
+++ b/src/useQuery/useQuery.spec.tsx
@@ -179,7 +179,7 @@ describe('useQuery', () => {
     expect(result.current.data).toEqual(['data', 'more data']);
   });
 
-  it('should not dispatch a redux action when the ignore cache options is passed', async () => {
+  it('should not dispatch a redux action when the ignore cache option is passed', async () => {
     const QUERY = () => ({
       domain: 'users',
       action: 'list',

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -64,9 +64,7 @@ const useQuery: (query: Query, variables?: any, options?: Options) => any = (
       // @TODO this promise should be cancellable
       API[domain][action](options)
         .then(data => {
-          if (!ignoreCache) {
-            store.dispatch(cacheQueryResult({ domain, action, options, data }));
-          }
+          store.dispatch(cacheQueryResult({ domain, action, options, data }));
 
           setState({
             loading: false,

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -15,11 +15,23 @@ type CalculatedQuery = {
 
 type Query = (variables?: any) => CalculatedQuery;
 
+type Options = {
+  ignoreCache: boolean;
+};
+
 const selectQueryData = (state, key) => {
   return state.queries[key];
 };
 
-const useQuery: (query: Query, variables?: any) => any = (query, variables) => {
+const defaultConfig = {
+  ignoreCache: false,
+};
+
+const useQuery: (query: Query, variables?: any, options?: Options) => any = (
+  query,
+  variables,
+  { ignoreCache = defaultConfig.ignoreCache } = defaultConfig,
+) => {
   const [state, setState] = useUpdatableState({
     loading: false,
     data: undefined,
@@ -38,11 +50,13 @@ const useQuery: (query: Query, variables?: any) => any = (query, variables) => {
     (domain, action, options, updateQuery) => {
       const key = generateQueryCacheKey({ domain, action, options });
 
-      // Check for previous results
-      const cacheResult = selectQueryData(store.getState(), key);
-      if (cacheResult) {
-        setState({ loading: false, data: cacheResult, error: undefined });
-        return;
+      if (!ignoreCache) {
+        // Check for previous results
+        const cacheResult = selectQueryData(store.getState(), key);
+        if (cacheResult) {
+          setState({ loading: false, data: cacheResult, error: undefined });
+          return;
+        }
       }
 
       setState({ loading: true, error: undefined });
@@ -50,7 +64,9 @@ const useQuery: (query: Query, variables?: any) => any = (query, variables) => {
       // @TODO this promise should be cancellable
       API[domain][action](options)
         .then(data => {
-          store.dispatch(cacheQueryResult({ domain, action, options, data }));
+          if (!ignoreCache) {
+            store.dispatch(cacheQueryResult({ domain, action, options, data }));
+          }
 
           setState({
             loading: false,


### PR DESCRIPTION
### Why

It can be useful to completely ignore the redux store and always refetch when a hook gets unmounted / mounted, for example:
  * We don't have a way to update the cache / force a refetch when a mutation occurs
   * Updating a value from legacy -> even harder to force a cache update

So I'm proposing an `ignoreCache` option that can be passed to the `useQuery` hook.