### PR TITLE
Entities & queries: dispatch actions and select from store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3440,6 +3440,11 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -3451,6 +3456,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
       "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
       "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2651,6 +2651,15 @@
         "isobject": "^3.0.1"
       }
     },
+    "is-reference": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.2.tgz",
+      "integrity": "sha512-Kn5g8c7XHKejFOpTf2QN9YjiHHKl5xRj+2uAZf9iM2//nkBNi/NNeB5JMoun28nEaUVHyPUzqzhfRlfAirEjXg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39"
+      }
+    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -3475,6 +3484,15 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -4433,6 +4451,38 @@
         "acorn": "^6.1.1"
       }
     },
+    "rollup-plugin-commonjs": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.0.0.tgz",
+      "integrity": "sha512-B8MoX5GRpj3kW4+YaFO/di2JsZkBxNjVmZ9LWjUoTAjq8N9wc7HObMXPsrvolVV9JXVtYSscflXM14A19dXPNQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.0",
+        "is-reference": "^1.1.2",
+        "magic-string": "^0.25.2",
+        "resolve": "^1.10.1",
+        "rollup-pluginutils": "^2.7.0"
+      },
+      "dependencies": {
+        "rollup-pluginutils": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
+          "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
+          "dev": true,
+          "requires": {
+            "estree-walker": "^0.6.1"
+          },
+          "dependencies": {
+            "estree-walker": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+              "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "rollup-plugin-node-resolve": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.0.0.tgz",
@@ -4762,6 +4812,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
       "dev": true
     },
     "spdx-correct": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3449,11 +3449,6 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   },
   "homepage": "https://github.com/teamleadercrm/react-hooks-api#readme",
   "dependencies": {
-    "immer": "^3.1.2"
+    "immer": "^3.1.2",
+    "lodash.get": "^4.4.2",
+    "lodash.set": "^4.3.2"
   },
   "devDependencies": {
     "@teamleader/api": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "redux": "^4.0.1",
     "redux-mock-store": "^1.5.3",
     "rollup": "^1.12.3",
+    "rollup-plugin-commonjs": "^10.0.0",
     "rollup-plugin-node-resolve": "^5.0.0",
     "rollup-plugin-typescript2": "^0.21.1",
     "ts-jest": "^24.0.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "homepage": "https://github.com/teamleadercrm/react-hooks-api#readme",
   "dependencies": {
     "immer": "^3.1.2",
-    "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,23 +11,23 @@ export default {
     {
       exports: 'named',
       file: packageJSON.main,
-      format: 'cjs'
+      format: 'cjs',
     },
     {
       file: packageJSON.module,
-      format: 'esm'
+      format: 'esm',
     },
   ],
   plugins: [
     typescriptPlugin({ typescript }),
     resolve({
       customResolveOptions: {
-        moduleDirectory: 'node_modules'
-      }
+        moduleDirectory: 'node_modules',
+      },
     }),
     commonjs({
       include: ['node_modules/lodash.get/index.js', 'node_modules/lodash.set/index.js'],
     }),
   ],
-  external: ['react', 'react-dom', 'react-redux', '@teamleader/api']
-}
+  external: ['react', 'react-dom', 'react-redux', '@teamleader/api'],
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,7 @@ export default {
       },
     }),
     commonjs({
-      include: ['node_modules/lodash.get/index.js', 'node_modules/lodash.set/index.js'],
+      include: ['node_modules/lodash.set/index.js'],
     }),
   ],
   external: ['react', 'react-dom', 'react-redux', '@teamleader/api'],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import resolve from 'rollup-plugin-node-resolve';
 import typescriptPlugin from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
+import commonjs from 'rollup-plugin-commonjs';
 
 import packageJSON from './package.json';
 
@@ -23,6 +24,9 @@ export default {
       customResolveOptions: {
         moduleDirectory: 'node_modules'
       }
+    }),
+    commonjs({
+      include: ['node_modules/lodash.get/index.js', 'node_modules/lodash.set/index.js'],
     }),
   ],
   external: ['react', 'react-dom', 'react-redux', '@teamleader/api']

--- a/src/store/entities/__tests__/selectors.spec.ts
+++ b/src/store/entities/__tests__/selectors.spec.ts
@@ -1,6 +1,6 @@
 import generateQueryCacheKey from '../../../utils/generateQueryCacheKey';
 
-import { selectMergedEntities } from '../selectors';
+import { selectMergedEntities, mergeEntitiesIntoPaths } from '../selectors';
 
 describe('Entities selectors', () => {
   const keys = {
@@ -145,6 +145,44 @@ describe('Entities selectors', () => {
       ];
 
       expect(selectedEntities).toEqual(resultEntities);
+    });
+  });
+
+  describe('mergeEntitiesIntoPaths', () => {
+    it('correctly selects the right entities from an entities state object and merges it into an existing entity', () => {
+      const entitiesState = {
+        contacts: {
+          '708c8008-3455-49a9-b66a-5222bcadb0cc': {
+            id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+            name: 'John Appleseed',
+          },
+        },
+      };
+
+      const mainEntity = {
+        id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+        participant: {
+          anotherKey: {
+            id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+            type: 'contact',
+          },
+        },
+      };
+
+      const paths = ['participant.anotherKey'];
+
+      const result = {
+        id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+        participant: {
+          anotherKey: {
+            id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+            type: 'contact',
+            name: 'John Appleseed',
+          },
+        },
+      };
+
+      expect(mergeEntitiesIntoPaths(entitiesState, paths, mainEntity)).toEqual(result);
     });
   });
 });

--- a/src/store/entities/__tests__/selectors.spec.ts
+++ b/src/store/entities/__tests__/selectors.spec.ts
@@ -16,6 +16,11 @@ describe('Entities selectors', () => {
       action: 'list',
       options: { include: 'customer' },
     }),
+    multipleProjectsKeyWithNestedIncludedData: generateQueryCacheKey({
+      domain: 'projects',
+      action: 'list',
+      options: { include: 'participants.participant' },
+    }),
   };
 
   const INITIAL_STATE = {
@@ -35,6 +40,34 @@ describe('Entities selectors', () => {
             id: '712419dc-7ac9-46b8-b954-32753fb28867',
           },
         },
+        'dbce36dc-328c-4e50-9685-471de7725b7b': {
+          id: 'dbce36dc-328c-4e50-9685-471de7725b7b',
+          participants: [
+            {
+              participant: {
+                type: 'user',
+                id: '2e46d7f5-6e9f-4d64-af13-c32cb6f72625',
+              },
+            },
+          ],
+        },
+        '5c04d510-a613-4281-9b1a-949a3ed0d982': {
+          id: '5c04d510-a613-4281-9b1a-949a3ed0d982',
+          participants: [
+            {
+              participant: {
+                type: 'user',
+                id: '2e46d7f5-6e9f-4d64-af13-c32cb6f72625',
+              },
+            },
+            {
+              participant: {
+                type: 'user',
+                id: '0f49cca0-2a58-4feb-a49c-d72728073635',
+              },
+            },
+          ],
+        },
       },
       contacts: {
         'bdb37478-d05c-466c-acc0-4f8427d7bc92': {
@@ -44,6 +77,16 @@ describe('Entities selectors', () => {
         '712419dc-7ac9-46b8-b954-32753fb28867': {
           id: '712419dc-7ac9-46b8-b954-32753fb28867',
           name: "John Appleseed's cousin",
+        },
+      },
+      users: {
+        '2e46d7f5-6e9f-4d64-af13-c32cb6f72625': {
+          id: '2e46d7f5-6e9f-4d64-af13-c32cb6f72625',
+          name: 'John Wick',
+        },
+        '0f49cca0-2a58-4feb-a49c-d72728073635': {
+          id: '0f49cca0-2a58-4feb-a49c-d72728073635',
+          name: "John Wick's cousin",
         },
       },
     },
@@ -63,6 +106,10 @@ describe('Entities selectors', () => {
       [keys.multipleProjectsKeyWithInclude]: {
         loading: false,
         ids: ['e6538393-aa7e-4ec2-870b-f75b3d85f706', '708c8008-3455-49a9-b66a-5222bcadb0cc'],
+      },
+      [keys.multipleProjectsKeyWithNestedIncludedData]: {
+        loading: false,
+        ids: ['dbce36dc-328c-4e50-9685-471de7725b7b', '5c04d510-a613-4281-9b1a-949a3ed0d982'],
       },
     },
   };
@@ -121,8 +168,6 @@ describe('Entities selectors', () => {
     });
 
     it('selects the correct collection of entities and merges the sideloaded entities', () => {
-      const key = 'multipleProjectsQuery';
-
       const selectedEntities = selectMergedEntities(INITIAL_STATE, { key: keys.multipleProjectsKeyWithInclude });
 
       const resultEntities = [
@@ -141,6 +186,48 @@ describe('Entities selectors', () => {
             id: '712419dc-7ac9-46b8-b954-32753fb28867',
             name: "John Appleseed's cousin",
           },
+        },
+      ];
+
+      expect(selectedEntities).toEqual(resultEntities);
+    });
+
+    it('can select and merge deeply nested sideloaded entities', () => {
+      const selectedEntities = selectMergedEntities(INITIAL_STATE, {
+        key: keys.multipleProjectsKeyWithNestedIncludedData,
+      });
+
+      const resultEntities = [
+        {
+          id: 'dbce36dc-328c-4e50-9685-471de7725b7b',
+          participants: [
+            {
+              participant: {
+                type: 'user',
+                id: '2e46d7f5-6e9f-4d64-af13-c32cb6f72625',
+                name: "John Wick",
+              },
+            },
+          ],
+        },
+        {
+          id: '5c04d510-a613-4281-9b1a-949a3ed0d982',
+          participants: [
+            {
+              participant: {
+                type: 'user',
+                id: '2e46d7f5-6e9f-4d64-af13-c32cb6f72625',
+                name: "John Wick",
+              },
+            },
+            {
+              participant: {
+                type: 'user',
+                id: '0f49cca0-2a58-4feb-a49c-d72728073635',
+                name: "John Wick's cousin",
+              },
+            },
+          ],
         },
       ];
 

--- a/src/store/entities/__tests__/selectors.spec.ts
+++ b/src/store/entities/__tests__/selectors.spec.ts
@@ -1,0 +1,150 @@
+import generateQueryCacheKey from '../../../utils/generateQueryCacheKey';
+
+import { selectMergedEntities } from '../selectors';
+
+describe('Entities selectors', () => {
+  const keys = {
+    singleProjectKey: generateQueryCacheKey({ domain: 'projects', action: 'info' }),
+    singleProjectKeyWithInclude: generateQueryCacheKey({
+      domain: 'projects',
+      action: 'info',
+      options: { include: 'customer' },
+    }),
+    multipleProjectsKey: generateQueryCacheKey({ domain: 'projects', action: 'list' }),
+    multipleProjectsKeyWithInclude: generateQueryCacheKey({
+      domain: 'projects',
+      action: 'list',
+      options: { include: 'customer' },
+    }),
+  };
+
+  const INITIAL_STATE = {
+    entities: {
+      projects: {
+        'e6538393-aa7e-4ec2-870b-f75b3d85f706': {
+          id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+          customer: {
+            type: 'contact',
+            id: 'bdb37478-d05c-466c-acc0-4f8427d7bc92',
+          },
+        },
+        '708c8008-3455-49a9-b66a-5222bcadb0cc': {
+          id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+          customer: {
+            type: 'contact',
+            id: '712419dc-7ac9-46b8-b954-32753fb28867',
+          },
+        },
+      },
+      contacts: {
+        'bdb37478-d05c-466c-acc0-4f8427d7bc92': {
+          id: 'bdb37478-d05c-466c-acc0-4f8427d7bc92',
+          name: 'John Appleseed',
+        },
+        '712419dc-7ac9-46b8-b954-32753fb28867': {
+          id: '712419dc-7ac9-46b8-b954-32753fb28867',
+          name: "John Appleseed's cousin",
+        },
+      },
+    },
+    queries: {
+      [keys.singleProjectKey]: {
+        loading: false,
+        ids: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+      },
+      [keys.singleProjectKeyWithInclude]: {
+        loading: false,
+        ids: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+      },
+      [keys.multipleProjectsKey]: {
+        loading: false,
+        ids: ['e6538393-aa7e-4ec2-870b-f75b3d85f706', '708c8008-3455-49a9-b66a-5222bcadb0cc'],
+      },
+      [keys.multipleProjectsKeyWithInclude]: {
+        loading: false,
+        ids: ['e6538393-aa7e-4ec2-870b-f75b3d85f706', '708c8008-3455-49a9-b66a-5222bcadb0cc'],
+      },
+    },
+  };
+
+  describe('selectMergedEntities', () => {
+    it('selects the correct entity based on the query', () => {
+      const selectedEntity = selectMergedEntities(INITIAL_STATE, { key: keys.singleProjectKey });
+
+      const resultEntity = {
+        id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+        customer: {
+          type: 'contact',
+          id: 'bdb37478-d05c-466c-acc0-4f8427d7bc92',
+        },
+      };
+
+      expect(selectedEntity).toEqual(resultEntity);
+    });
+
+    it('selects the correct entity and merges the sideloaded entities', () => {
+      const selectedEntity = selectMergedEntities(INITIAL_STATE, { key: keys.singleProjectKeyWithInclude });
+
+      const resultEntity = {
+        id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+        customer: {
+          type: 'contact',
+          id: 'bdb37478-d05c-466c-acc0-4f8427d7bc92',
+          name: 'John Appleseed',
+        },
+      };
+
+      expect(selectedEntity).toEqual(resultEntity);
+    });
+
+    it('selects the correct entities when a collection was requested', () => {
+      const selectedEntities = selectMergedEntities(INITIAL_STATE, { key: keys.multipleProjectsKey });
+
+      const resultEntities = [
+        {
+          id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+          customer: {
+            type: 'contact',
+            id: 'bdb37478-d05c-466c-acc0-4f8427d7bc92',
+          },
+        },
+        {
+          id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+          customer: {
+            type: 'contact',
+            id: '712419dc-7ac9-46b8-b954-32753fb28867',
+          },
+        },
+      ];
+
+      expect(selectedEntities).toEqual(resultEntities);
+    });
+
+    it('selects the correct collection of entities and merges the sideloaded entities', () => {
+      const key = 'multipleProjectsQuery';
+
+      const selectedEntities = selectMergedEntities(INITIAL_STATE, { key: keys.multipleProjectsKeyWithInclude });
+
+      const resultEntities = [
+        {
+          id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+          customer: {
+            type: 'contact',
+            id: 'bdb37478-d05c-466c-acc0-4f8427d7bc92',
+            name: 'John Appleseed',
+          },
+        },
+        {
+          id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+          customer: {
+            type: 'contact',
+            id: '712419dc-7ac9-46b8-b954-32753fb28867',
+            name: "John Appleseed's cousin",
+          },
+        },
+      ];
+
+      expect(selectedEntities).toEqual(resultEntities);
+    });
+  });
+});

--- a/src/store/entities/constants.ts
+++ b/src/store/entities/constants.ts
@@ -24,5 +24,5 @@ export const TYPE_DOMAIN_MAPPING = {
   customFieldDefinition: 'customFieldDefinitions',
   workType: 'workTypes',
   task: 'tasks',
-  todo: 'tasks.list', // Deprecated, `task` should be used instead
+  todo: 'tasks', // Deprecated, `task` should be used instead
 };

--- a/src/store/entities/constants.ts
+++ b/src/store/entities/constants.ts
@@ -1,1 +1,28 @@
 export const SAVE_NORMALIZED_ENTITIES = 'SAVE_NORMALIZED_ENTITIES';
+
+export const TYPE_DOMAIN_MAPPING = {
+  contact: 'contacts',
+  company: 'companies',
+  user: 'users',
+  businessType: 'businessTypes',
+  deal: 'deals',
+  dealPhase: 'dealPhases',
+  dealSource: 'dealSources',
+  quotation: 'quotations',
+  event: 'events',
+  activityType: 'activityTypes',
+  invoice: 'invoices',
+  creditNote: 'creditNotes',
+  taxRate: 'taxRates',
+  paymentTerm: 'paymentTerms',
+  product: 'products',
+  productCategory: 'productCategories',
+  project: 'projects',
+  milestone: 'milestones',
+  timeTracking: 'timeTracking',
+  departments: 'departments',
+  customFieldDefinition: 'customFieldDefinitions',
+  workType: 'workTypes',
+  task: 'tasks',
+  todo: 'tasks.list', // Deprecated, `task` should be used instead
+};

--- a/src/store/entities/selectors.ts
+++ b/src/store/entities/selectors.ts
@@ -1,0 +1,71 @@
+import set from 'lodash.set';
+import get from 'lodash.get';
+
+import decodeQueryCacheKey from '../../utils/decodeQueryCacheKey';
+
+import { State } from '../reducer';
+import { State as EntitiesState } from '../entities/reducer';
+import { Entity } from '../../typings/API';
+
+/**
+ * @TODO
+ * Helper function to determine how to convert an api entity reference; f.e.
+ * { type: 'contact', id: 'test123' }
+ * into the domain type "contacts", should this be revised in the api or should we
+ * change our store to store directly by type, or create a mapping?
+ */
+export const convertAPIEntityTypeToDomain = (type: string) => {
+  return `${type}s`;
+};
+
+/**
+ * Helper function to merge entities into their respective paths
+ * Returns a new, non-mutated entity object
+ */
+export const mergeEntitiesIntoPaths = (entities: EntitiesState, paths: string[], entity: Entity) => {
+  const clonedEntity = { ...entity };
+
+  paths.forEach(path => {
+    const sideloadReference = get(entity, path);
+
+    const sideloadedEntity = entities[convertAPIEntityTypeToDomain(sideloadReference.type)][sideloadReference.id];
+
+    set(clonedEntity, path, { ...sideloadReference, ...sideloadedEntity });
+  });
+
+  return clonedEntity;
+};
+
+export const selectMergedEntities = (state: State, { key }: { key: string }) => {
+  const { ids } = state.queries[key];
+  const { domain, options } = decodeQueryCacheKey(key);
+
+  const include = options && options.include;
+
+  // single entity, aka .info request
+  if (typeof ids === 'string') {
+    const entity = state.entities[domain][ids];
+
+    if (include) {
+      const entityPaths = include.split(',');
+
+      return mergeEntitiesIntoPaths(state.entities, entityPaths, entity);
+    }
+
+    return entity;
+  }
+
+  const entities = ids.map(id => state.entities[domain][id]);
+
+  if (include) {
+    const entityPaths = include.split(',');
+
+    const entitiesWithIncludedEntities = entities.map(entity => {
+      return mergeEntitiesIntoPaths(state.entities, entityPaths, entity);
+    });
+
+    return entitiesWithIncludedEntities;
+  }
+
+  return entities;
+};

--- a/src/store/entities/selectors.ts
+++ b/src/store/entities/selectors.ts
@@ -6,17 +6,7 @@ import decodeQueryCacheKey from '../../utils/decodeQueryCacheKey';
 import { State } from '../reducer';
 import { State as EntitiesState } from '../entities/reducer';
 import { Entity } from '../../typings/API';
-
-/**
- * @TODO
- * Helper function to determine how to convert an api entity reference; f.e.
- * { type: 'contact', id: 'test123' }
- * into the domain type "contacts", should this be revised in the api or should we
- * change our store to store directly by type, or create a mapping?
- */
-export const convertAPIEntityTypeToDomain = (type: string) => {
-  return `${type}s`;
-};
+import { TYPE_DOMAIN_MAPPING } from './constants';
 
 /**
  * Helper function to merge entities into their respective paths
@@ -28,7 +18,7 @@ export const mergeEntitiesIntoPaths = (entities: EntitiesState, paths: string[],
   paths.forEach(path => {
     const sideloadReference = get(entity, path);
 
-    const sideloadedEntity = entities[convertAPIEntityTypeToDomain(sideloadReference.type)][sideloadReference.id];
+    const sideloadedEntity = entities[TYPE_DOMAIN_MAPPING[sideloadReference.type]][sideloadReference.id];
 
     set(clonedEntity, path, { ...sideloadReference, ...sideloadedEntity });
   });

--- a/src/store/entities/selectors.ts
+++ b/src/store/entities/selectors.ts
@@ -1,3 +1,4 @@
+import produce from 'immer';
 import set from 'lodash.set';
 import get from 'lodash.get';
 
@@ -13,17 +14,15 @@ import { TYPE_DOMAIN_MAPPING } from './constants';
  * Returns a new, non-mutated entity object
  */
 export const mergeEntitiesIntoPaths = (entities: EntitiesState, paths: string[], entity: Entity) => {
-  const clonedEntity = { ...entity };
+  return produce(entity, draftEntity => {
+    paths.forEach(path => {
+      const sideloadReference = get(entity, path);
 
-  paths.forEach(path => {
-    const sideloadReference = get(entity, path);
+      const sideloadedEntity = entities[TYPE_DOMAIN_MAPPING[sideloadReference.type]][sideloadReference.id];
 
-    const sideloadedEntity = entities[TYPE_DOMAIN_MAPPING[sideloadReference.type]][sideloadReference.id];
-
-    set(clonedEntity, path, { ...sideloadReference, ...sideloadedEntity });
-  });
-
-  return clonedEntity;
+      set(draftEntity, path, { ...sideloadReference, ...sideloadedEntity });
+    });
+  })
 };
 
 export const selectMergedEntities = (state: State, { key }: { key: string }) => {

--- a/src/store/queries/__tests__/selectors.spec.ts
+++ b/src/store/queries/__tests__/selectors.spec.ts
@@ -1,0 +1,27 @@
+import { selectQuery, selectMetaFromQuery } from '../selectors';
+
+describe('queries selectors', () => {
+  const INITIAL_STATE = {
+    entities: {},
+    queries: {
+      uniqueKey: {
+        loading: false,
+        meta: {
+          matches: 2,
+        },
+      },
+    },
+  };
+
+  it('selects the correct query', () => {
+    const query = selectQuery(INITIAL_STATE, 'uniqueKey');
+
+    expect(query).toEqual({ loading: false, meta: { matches: 2 } });
+  });
+
+  it('selects the meta of the query', () => {
+    const meta = selectMetaFromQuery(INITIAL_STATE, 'uniqueKey');
+
+    expect(meta).toEqual({ matches: 2 });
+  });
+});

--- a/src/store/queries/actions.ts
+++ b/src/store/queries/actions.ts
@@ -4,4 +4,4 @@ import { QUERY_REQUEST, QUERY_FAILURE, QUERY_SUCCESS } from './constants';
 
 export const queryRequest = createStandardAction(QUERY_REQUEST)<{ key: string }>();
 export const queryFailure = createStandardAction(QUERY_FAILURE)<{ key: string; error: Error }>();
-export const querySuccess = createStandardAction(QUERY_SUCCESS)<{ key: string; ids: string[]; meta?: any }>();
+export const querySuccess = createStandardAction(QUERY_SUCCESS)<{ key: string; ids: string | string[]; meta?: any }>();

--- a/src/store/queries/reducer.ts
+++ b/src/store/queries/reducer.ts
@@ -8,7 +8,7 @@ export type State = DeepReadonly<{
   [key: string]: {
     loading: boolean;
     error?: Error;
-    ids?: string[];
+    ids?: string | string[];
     meta?: any;
   };
 }>;

--- a/src/store/queries/selectors.ts
+++ b/src/store/queries/selectors.ts
@@ -1,0 +1,9 @@
+import { State } from '../reducer';
+
+export const selectQuery = (state: State, key: string) => {
+  return state.queries[key];
+};
+
+export const selectMetaFromQuery = (state: State, key: string) => {
+  return selectQuery(state, key).meta;
+};

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -1,7 +1,13 @@
 import { combineReducers } from 'redux';
+import { DeepReadonly } from 'utility-types';
 
-import queries from './queries/reducer';
-import entities from './entities/reducer';
+import queries, { State as QueriesState } from './queries/reducer';
+import entities, { State as EntitiesState } from './entities/reducer';
+
+export type State = DeepReadonly<{
+  queries: QueriesState;
+  entities: EntitiesState;
+}>;
 
 export default combineReducers({
   queries,

--- a/src/useQuery/useQuery.spec.tsx
+++ b/src/useQuery/useQuery.spec.tsx
@@ -6,9 +6,11 @@ import { Store } from 'redux';
 
 import useQuery from './useQuery';
 import generateQueryCacheKey from '../utils/generateQueryCacheKey';
-import { CACHE_QUERY_RESULT } from '../store/constants';
 import Context from '../Context';
 import CustomReduxContext from '../store/CustomReduxContext';
+import { queryRequest, querySuccess } from '../store/queries/actions';
+import { saveNormalizedEntities } from '../store/entities/actions';
+import { State } from '../store/reducer';
 
 const mockAPI = {
   users: {
@@ -16,9 +18,11 @@ const mockAPI = {
     list: options => {
       return new Promise((resolve, reject) => {
         if (options && options.page === 2) {
-          resolve('more data');
+          resolve({ data: [{ id: 'e57a6047-cb52-4273-9df7-1d55c2c6e36d' }] });
         }
-        resolve('data');
+        resolve({
+          data: [{ id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706' }, { id: '708c8008-3455-49a9-b66a-5222bcadb0cc' }],
+        });
       });
     },
     info: options => {
@@ -31,11 +35,35 @@ const mockAPI = {
   },
 };
 
+const initialMockState: State = {
+  entities: {},
+  queries: {},
+};
+
+const mockedStateAfterUsersListResolve = {
+  queries: {
+    [generateQueryCacheKey({ domain: 'users', action: 'list' })]: {
+      loading: false,
+      ids: ['e6538393-aa7e-4ec2-870b-f75b3d85f706', '708c8008-3455-49a9-b66a-5222bcadb0cc'],
+    },
+  },
+  entities: {
+    users: {
+      'e6538393-aa7e-4ec2-870b-f75b3d85f706': {
+        id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+      },
+      '708c8008-3455-49a9-b66a-5222bcadb0cc': {
+        id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+      },
+    },
+  },
+};
+
 const StoreWrapper = (passedStore?: Store) => {
   let store = passedStore;
   // initialize a default store
   if (!passedStore) {
-    store = configureStore([])({ queries: {} });
+    store = configureStore([])(() => initialMockState);
   }
 
   return ({ children }) => (
@@ -62,7 +90,7 @@ describe('useQuery', () => {
     expect(result.current.fetchMore).toBeInstanceOf(Function);
   });
 
-  it('should dispatch a caching action when the resolved data is not cached yet', async () => {
+  it('should dispatch a queryRequest action when a query is requested for the first time', async () => {
     const QUERY = () => ({
       domain: 'users',
       action: 'list',
@@ -70,19 +98,55 @@ describe('useQuery', () => {
 
     const store = configureStore([])({ queries: {} });
 
-    const { waitForNextUpdate } = renderHook(() => useQuery(QUERY), { wrapper: StoreWrapper(store) });
+    renderHook(() => useQuery(QUERY), { wrapper: StoreWrapper(store) });
 
-    // wait for request to resolve
-    await waitForNextUpdate();
+    const key = generateQueryCacheKey({ domain: 'users', action: 'list' });
 
-    const expectedType = CACHE_QUERY_RESULT;
-    const expectedPayload = {
+    const action = queryRequest({ key });
+
+    expect(store.getActions()).toEqual([action]);
+  });
+
+  it('should dispatch a querySuccess and saveNormalizedEntities action when a query is successfully resolved', async () => {
+    const QUERY = () => ({
       domain: 'users',
       action: 'list',
-      data: 'data',
-    };
+    });
 
-    expect(store.getActions()).toEqual([{ type: expectedType, payload: expectedPayload }]);
+    const key = generateQueryCacheKey({ domain: 'users', action: 'list' });
+
+    let state = { ...initialMockState };
+    const store = configureStore([])(() => state);
+
+    const { waitForNextUpdate } = renderHook(() => useQuery(QUERY), { wrapper: StoreWrapper(store) });
+
+    state = mockedStateAfterUsersListResolve;
+
+    await waitForNextUpdate();
+
+    const actions = [
+      querySuccess({
+        key,
+        ids: ['e6538393-aa7e-4ec2-870b-f75b3d85f706', '708c8008-3455-49a9-b66a-5222bcadb0cc'],
+      }),
+      saveNormalizedEntities({
+        type: 'users',
+        entities: {
+          'e6538393-aa7e-4ec2-870b-f75b3d85f706': {
+            id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+          },
+          '708c8008-3455-49a9-b66a-5222bcadb0cc': {
+            id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+          },
+        },
+      }),
+    ];
+
+    const allActions = store.getActions();
+    // skip first request action
+    allActions.shift();
+
+    expect(allActions).toEqual(actions);
   });
 
   it('should return the resolved data', async () => {
@@ -91,12 +155,26 @@ describe('useQuery', () => {
       action: 'list',
     });
 
-    const { result, waitForNextUpdate } = renderHook(() => useQuery(QUERY), { wrapper: StoreWrapper() });
+    const key = generateQueryCacheKey({ domain: 'users', action: 'list' });
+
+    let state = { ...initialMockState };
+    const store = configureStore([])(() => state);
+
+    const { result, waitForNextUpdate } = renderHook(() => useQuery(QUERY), { wrapper: StoreWrapper(store) });
+
+    state = mockedStateAfterUsersListResolve;
 
     await waitForNextUpdate();
 
     expect(result.current.loading).toEqual(false);
-    expect(result.current.data).toEqual('data');
+    expect(result.current.data).toEqual([
+      {
+        id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+      },
+      {
+        id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+      },
+    ]);
   });
 
   it('should return the error if the API request fails', async () => {
@@ -119,14 +197,19 @@ describe('useQuery', () => {
       action: 'list',
     });
 
-    const storeKey = generateQueryCacheKey(QUERY());
-
-    const store = configureStore([])({ queries: { [storeKey]: 'cachedData' } });
+    const store = configureStore([])(mockedStateAfterUsersListResolve);
 
     const { result } = renderHook(() => useQuery(QUERY), { wrapper: StoreWrapper(store) });
 
     expect(result.current.loading).toEqual(false);
-    expect(result.current.data).toEqual('cachedData');
+    expect(result.current.data).toEqual([
+      {
+        id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+      },
+      {
+        id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+      },
+    ]);
   });
 
   it('should clear the error when variables have changed', async () => {
@@ -162,20 +245,61 @@ describe('useQuery', () => {
       },
     });
 
-    const { result, waitForNextUpdate } = renderHook(() => useQuery(QUERY, { page: 1 }), { wrapper: StoreWrapper() });
+    let state = initialMockState;
+    const store = configureStore([])(() => state);
 
+    const { result, waitForNextUpdate } = renderHook(() => useQuery(QUERY, { page: 1 }), {
+      wrapper: StoreWrapper(store),
+    });
+
+    state = {
+      ...mockedStateAfterUsersListResolve,
+      queries: {
+        [generateQueryCacheKey({ domain: 'users', action: 'list', options: { page: 1 } })]: {
+          loading: false,
+          ids: ['e6538393-aa7e-4ec2-870b-f75b3d85f706', '708c8008-3455-49a9-b66a-5222bcadb0cc'],
+        },
+      },
+    };
     await waitForNextUpdate();
 
     result.current.fetchMore({
       variables: { page: 2 },
-      updateQuery: ({ previousData, data }) => [previousData, data],
+      updateQuery: ({ previousData, data }) => [...previousData, ...data],
     });
 
     expect(result.current.loading).toBeTruthy();
 
+    state = {
+      entities: {
+        users: {
+          ...state.entities.users,
+          'e57a6047-cb52-4273-9df7-1d55c2c6e36d': {
+            id: 'e57a6047-cb52-4273-9df7-1d55c2c6e36d',
+          },
+        },
+      },
+      queries: {
+        ...state.queries,
+        [generateQueryCacheKey({ domain: 'users', action: 'list', options: { page: 2 } })]: {
+          loading: false,
+          ids: ['e57a6047-cb52-4273-9df7-1d55c2c6e36d'],
+        },
+      },
+    };
     await waitForNextUpdate();
 
+    const resultData = [
+      {
+        id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+      },
+      {
+        id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+      },
+      { id: 'e57a6047-cb52-4273-9df7-1d55c2c6e36d' },
+    ];
+
     expect(result.current.loading).toEqual(false);
-    expect(result.current.data).toEqual(['data', 'more data']);
+    expect(result.current.data).toEqual(resultData);
   });
 });

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -9,6 +9,7 @@ import { queryRequest, querySuccess, queryFailure } from '../store/queries/actio
 import CustomReduxContext from '../store/CustomReduxContext';
 import Context from '../Context';
 import { saveNormalizedEntities } from '../store/entities/actions';
+import { selectMergedEntities } from '../store/entities/selectors';
 
 type CalculatedQuery = {
   domain: string;
@@ -72,9 +73,11 @@ const useQuery: (query: Query, variables?: any) => any = (query, variables) => {
             });
           }
 
+          const mergedEntities = selectMergedEntities(store.getState(), { key });
+
           setState({
             loading: false,
-            data: updateQuery ? updateQuery({ previousData: state.data, data }) : data,
+            data: updateQuery ? updateQuery({ previousData: state.data, data: mergedEntities }) : mergedEntities,
           });
         })
         .catch(error => {

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -20,10 +20,6 @@ type CalculatedQuery = {
 
 type Query = (variables?: any) => CalculatedQuery;
 
-const selectQueryData = (state, key) => {
-  return state.queries[key];
-};
-
 const useQuery: (query: Query, variables?: any) => any = (query, variables) => {
   const [state, setState] = useUpdatableState({
     loading: false,

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -11,6 +11,7 @@ import Context from '../Context';
 import { saveNormalizedEntities } from '../store/entities/actions';
 import { selectMergedEntities } from '../store/entities/selectors';
 import { selectQuery, selectMetaFromQuery } from '../store/queries/selectors';
+import { TYPE_DOMAIN_MAPPING } from '../store/entities/constants';
 
 type CalculatedQuery = {
   domain: string;
@@ -69,7 +70,8 @@ const useQuery: (query: Query, variables?: any) => any = (query, variables) => {
           if (response.included) {
             Object.keys(response.included).forEach(entityType => {
               const normalizedEntities = normalize(response.included[entityType]);
-              store.dispatch(saveNormalizedEntities({ type: entityType, entities: normalizedEntities }));
+              const domainFromType = TYPE_DOMAIN_MAPPING[entityType];
+              store.dispatch(saveNormalizedEntities({ type: domainFromType, entities: normalizedEntities }));
             });
           }
 

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -58,7 +58,7 @@ const useQuery: (query: Query, variables?: any) => any = (query, variables) => {
           store.dispatch(
             querySuccess({
               key,
-              ids: Array.isArray(response.data) ? response.data.map(entity => entity.id) : [response.data.id],
+              ids: Array.isArray(response.data) ? response.data.map(entity => entity.id) : response.data.id,
               meta: response.meta,
             }),
           );

--- a/src/utils/decodeQueryCacheKey.ts
+++ b/src/utils/decodeQueryCacheKey.ts
@@ -1,0 +1,3 @@
+const decodeQueryCacheKey = (key: string) => JSON.parse(key);
+
+export default decodeQueryCacheKey;

--- a/src/utils/normalize/index.ts
+++ b/src/utils/normalize/index.ts
@@ -1,0 +1,2 @@
+import normalize from './normalize';
+export default normalize;

--- a/src/utils/normalize/normalize.spec.ts
+++ b/src/utils/normalize/normalize.spec.ts
@@ -1,0 +1,49 @@
+import normalize from './normalize';
+
+describe('normalize', () => {
+  it('correctly normalizes a single entity', () => {
+    const entity = {
+      id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+      property: 'a property',
+    };
+
+    const normalizedEntity = {
+      '708c8008-3455-49a9-b66a-5222bcadb0cc': {
+        id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+        property: 'a property',
+      },
+    };
+
+    expect(normalize(entity)).toEqual(normalizedEntity);
+  });
+
+  it('correctly normalizes an array of entities', () => {
+    const entities = [
+      {
+        id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+        property: 'a property',
+      },
+      {
+        id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+        property: 'a property',
+      },
+    ];
+
+    const normalizedEntities = {
+      '708c8008-3455-49a9-b66a-5222bcadb0cc': {
+        id: '708c8008-3455-49a9-b66a-5222bcadb0cc',
+        property: 'a property',
+      },
+      'e6538393-aa7e-4ec2-870b-f75b3d85f706': {
+        id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+        property: 'a property',
+      },
+    };
+
+    expect(normalize(entities)).toEqual(normalizedEntities);
+  });
+
+  it('returns an empty object when an empty array of entities is passed', () => {
+    expect(normalize([])).toEqual({});
+  });
+});

--- a/src/utils/normalize/normalize.ts
+++ b/src/utils/normalize/normalize.ts
@@ -1,0 +1,23 @@
+import { Entity } from '../../typings/API';
+
+const normalize = (data: Entity | Entity[]) => {
+  if (Array.isArray(data)) {
+    return data.reduce(
+      (normalizedEntities, entity) => ({
+        ...normalizedEntities,
+        [entity.id]: entity,
+      }),
+      {},
+    );
+  }
+
+  if (Object.keys(data).length === 0) {
+    return data;
+  }
+
+  return {
+    [data.id]: data,
+  };
+};
+
+export default normalize;

--- a/src/utils/referenceResolver.ts
+++ b/src/utils/referenceResolver.ts
@@ -1,8 +1,8 @@
-const convertPathToKeys = path => {
+const convertPathToKeys = (path: string) => {
   return path.split('.');
 };
 
-const resolveForCondition = condition => (object, keys) => {
+const resolveForCondition = (condition: (item: object | object[]) => boolean) => (object: object, keys: string[]) => {
   try {
     const item = object[keys[0]];
 
@@ -28,7 +28,7 @@ const resolveForCondition = condition => (object, keys) => {
   }
 };
 
-const isRelationship = item => {
+const isRelationship = (item: object) => {
   if (typeof item !== 'object') {
     return false;
   }
@@ -36,7 +36,7 @@ const isRelationship = item => {
   return item.hasOwnProperty('type') && item.hasOwnProperty('id');
 };
 
-const isListOfRelationships = (item) => {
+const isListOfRelationships = (item: object | object[]) => {
   if (!Array.isArray(item)) {
     return false;
   }

--- a/src/utils/referenceResolver.ts
+++ b/src/utils/referenceResolver.ts
@@ -1,0 +1,50 @@
+const convertPathToKeys = path => {
+  return path.split('.');
+};
+
+const resolveForCondition = condition => (object, keys) => {
+  try {
+    const item = object[keys[0]];
+
+    if (item === null) {
+      return null;
+    }
+
+    if (condition(item)) {
+      return item;
+    }
+
+    // if the item is an array, we need to dig deeper for possible references
+    if (Array.isArray(item)) {
+      return item.map(arrayItem =>
+        resolveForCondition(condition)(arrayItem, keys.filter((_, index) => index !== 0))
+      );
+    }
+
+    // remove first key from array, we've checked it, keep digging deeper
+    return resolveForCondition(condition)(item, keys.filter((_, index) => index !== 0));
+  } catch (exception) {
+    throw new Error("Couldn't resolve path for object");
+  }
+};
+
+const isRelationship = item => {
+  if (typeof item !== 'object') {
+    return false;
+  }
+
+  return item.hasOwnProperty('type') && item.hasOwnProperty('id');
+};
+
+const isListOfRelationships = (item) => {
+  if (!Array.isArray(item)) {
+    return false;
+  }
+
+  return isRelationship(item[0]);
+};
+
+const resolveReferences = resolveForCondition(item => isListOfRelationships(item) || isRelationship(item));
+
+export { convertPathToKeys };
+export default resolveReferences;


### PR DESCRIPTION
Related to #3 

### Changed

In this PR we write some selectors to correctly select the data from the store and we use them in the `useQuery` hook. Most of the additions are tests and isolated util functions, so don't be thrown off by the lines added.

### Next up

Merging this into the integration branch and doing a small release. We should also get rid of the double state (component state) in the future and make the hook solely rely on the store state.