### PR TITLE
🐛Don't return anything if the query hasn't finished loading yet

### DIFF
--- a/src/store/entities/selectors.ts
+++ b/src/store/entities/selectors.ts
@@ -49,6 +49,12 @@ export const mergeEntitiesIntoPaths = (entities: EntitiesState, paths: string[],
 
 export const selectMergedEntities = (state: State, { key }: { key: string }) => {
   const { ids, data } = state.queries[key];
+
+  // Query hasn't finished loading yet
+  if (!ids && !data) {
+    return null;
+  }
+
   const { domain, options } = decodeQueryCacheKey(key);
 
   const include = options && options.include;


### PR DESCRIPTION
### Fixed

* Don't try to map over the ids of the query if the query is still loading