### PR TITLE
Implement global access to queries

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,10 @@
-import useQuery from './useQuery';
+import useQuery, { queries } from './useQuery';
 import Provider from './Provider';
 
-export { useQuery, Provider };
+export { queries, useQuery, Provider };
 
 export default {
+  queries,
   useQuery,
-  Provider
+  Provider,
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,14 @@
 import useQuery, { queries } from './useQuery';
 import Provider from './Provider';
+import decodeQueryCacheKey from './utils/decodeQueryCacheKey';
+import generateQueryCacheKey from './utils/generateQueryCacheKey';
 
-export { queries, useQuery, Provider };
+export { queries, useQuery, Provider, decodeQueryCacheKey, generateQueryCacheKey };
 
 export default {
   queries,
   useQuery,
   Provider,
+  decodeQueryCacheKey,
+  generateQueryCacheKey
 }

--- a/src/useQuery/index.ts
+++ b/src/useQuery/index.ts
@@ -1,2 +1,3 @@
-import useQuery from './useQuery';
+import useQuery, { queries } from './useQuery';
+export { queries };
 export default useQuery;


### PR DESCRIPTION
### Added

* we now export a global `queries` object, when queries run, they register themselves inside of this object and house a `fetch` function. This way, a refetch can be triggered for certain queries as a reaction to f.e. a mutation. It's not an ideal solution, but it will have to do for now. It's also a pretty small change.
* added exports for internally used `decodeQueryCacheKey` and `generateQueryCacheKey`