### PR TITLE
🐛Fix sideloading array references with value null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 🐛 Fixed
+
+* Fix error when trying to merge array references that can be `null` ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#204](https://github.com/teamleadercrm/react-hooks-api/pull/204))
+
 ## [0.1.0-rc8] - 2020-01-23
 
 ### 🐛 Fixed

--- a/src/store/entities/__tests__/selectors.spec.ts
+++ b/src/store/entities/__tests__/selectors.spec.ts
@@ -295,5 +295,26 @@ describe('Entities selectors', () => {
 
       expect(mergeEntitiesIntoPaths(entitiesState, paths, mainEntity)).toEqual(result);
     })
+
+    it('Does not crash when the entity reference is optional (null)', () => {
+      const entitiesState = {};
+
+      const mainEntity = {
+        id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+        customFields: [
+          {
+            value: null,
+            definition: {
+              type: 'definition',
+              id: '2b8861d8-7e25-49dd-9fec-f38f35f0d821'
+            }
+          }
+        ],
+      };
+
+      const paths = ['customFields.value'];
+
+      expect(mergeEntitiesIntoPaths(entitiesState, paths, mainEntity)).toEqual(mainEntity);
+    })
   });
 });

--- a/src/store/entities/selectors.ts
+++ b/src/store/entities/selectors.ts
@@ -20,14 +20,14 @@ export const mergeEntitiesIntoPaths = (entities: EntitiesState, paths: string[],
       const keys = convertPathToKeys(path).map(camelCase);
       const sideloadReference = resolveReferences(entity, keys);
 
-      if (sideloadReference === null) {
-        return;
-      }
-
       let sideloadedEntity = null;
 
       if (Array.isArray(sideloadReference)) {
         sideloadReference.forEach((reference, index) => {
+          if (reference === null) {
+            return;
+          }
+
           sideloadedEntity = entities[TYPE_DOMAIN_MAPPING[reference.type]]?.[reference.id];
 
           // @TODO, hard coding the keys here means we only allow the first key to be an array of possible references
@@ -37,6 +37,10 @@ export const mergeEntitiesIntoPaths = (entities: EntitiesState, paths: string[],
           set(draftEntity, referencePath, { ...reference, ...sideloadedEntity })
         });
 
+        return;
+      }
+
+      if (sideloadReference === null) {
         return;
       }
 


### PR DESCRIPTION
### Fixed

* Fix error when trying to merge array references that can be `null`