### PR TITLE
🐛 Fix referenceResolver for unconventional paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [unreleased]
+
+### 🐛 Fixed
+
+* Fix a bug when automatically merging side-loaded entities causing problems with unconventional paths ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#245](https://github.com/teamleadercrm/react-hooks-api/pull/245))
+
 ## [0.1.0-rc11] - 2020-01-29
 
 This version is a republish of a version 0.1.0-rc10 because the wrong version was published under that tag.

--- a/src/store/entities/__tests__/selectors.spec.ts
+++ b/src/store/entities/__tests__/selectors.spec.ts
@@ -351,5 +351,25 @@ describe('Entities selectors', () => {
 
       expect(mergeEntitiesIntoPaths(entitiesState, paths, mainEntity)).toEqual(mainEntity);
     })
+
+    it('Does not erase paths that are not references', () => {
+      const entities = {};
+      const mainEntity = {
+        id: 'e6538393-aa7e-4ec2-870b-f75b3d85f706',
+        customFields: [
+          {
+            value: ['An option', 'Another option'],
+            definition: {
+              type: 'definition',
+              id: '2b8861d8-7e25-49dd-9fec-f38f35f0d821'
+            }
+          }
+        ],
+      };
+
+      const paths = ['customFields.value'];
+
+      expect((mergeEntitiesIntoPaths(entities, paths, mainEntity) as any).customFields[0].value).toEqual(['An option', 'Another option']);
+    })
   });
 });

--- a/src/utils/referenceResolver.ts
+++ b/src/utils/referenceResolver.ts
@@ -15,15 +15,22 @@ const resolveForCondition = (condition: (item: object | object[]) => boolean) =>
       return item;
     }
 
+    const nextKeys = keys.filter((_, index) => index !== 0);
+
+    // No more paths to look for, we've run out of keys
+    if (nextKeys.length === 0) {
+      return null;
+    }
+
     // if the item is an array, we need to dig deeper for possible references
     if (Array.isArray(item)) {
       return item.map(arrayItem =>
-        resolveForCondition(condition)(arrayItem, keys.filter((_, index) => index !== 0))
+        resolveForCondition(condition)(arrayItem, nextKeys)
       );
     }
 
     // remove first key from array, we've checked it, keep digging deeper
-    return resolveForCondition(condition)(item, keys.filter((_, index) => index !== 0));
+    return resolveForCondition(condition)(item, nextKeys);
   } catch (exception) {
     throw new Error("Couldn't resolve path for object");
   }


### PR DESCRIPTION
### Fixed

* There was some weird behaviour when the reference is potentially an array that doesn't contain another reference, this has been fixed