### PR TITLE
Re-introduce working version of fetchMore

### DIFF
--- a/src/store/entities/__tests__/selectors.spec.ts
+++ b/src/store/entities/__tests__/selectors.spec.ts
@@ -5,6 +5,7 @@ import {
   selectEntitiesFromQueryFactory,
   selectEntityByDomainAndIdFactory,
   selectEntitiesByDomainAndIdsFactory,
+  selectEntitiesFromQueryWithUpdateQueriesFactory,
 } from '../selectors';
 import generateQueryCacheKey from '../../../utils/generateQueryCacheKey';
 
@@ -172,6 +173,64 @@ describe('Entities selectors', () => {
         {
           id: '840958a7-b448-45be-9400-c90da58073ee',
           name: 'a project',
+        },
+      ]);
+    });
+  });
+
+  describe('selectEntitiesFromQueryWithUpdateQueriesFactory', () => {
+    const selectEntitiesFromQueryWithUpdateQueries = selectEntitiesFromQueryWithUpdateQueriesFactory();
+
+    it('selects the combined data based with updateQueries', () => {
+      const generateProjectDomainKey = (name) => generateQueryCacheKey({ domain: 'projects', options: name });
+      const mainKey = generateProjectDomainKey('mainKey');
+      const secondKey = generateProjectDomainKey('secondKey');
+      const updateQueries = {
+        [secondKey]: ({ previousData, data }: { previousData: any; data: any }) => [...previousData, ...data],
+      };
+      const state = {
+        queries: {
+          [mainKey]: {
+            loading: false,
+            ids: ['3e85d310-4ac5-444d-8465-de39767af6c7', '816105f4-37a8-4ff5-819b-d9597df18128'],
+          },
+          [secondKey]: {
+            loading: false,
+            ids: ['fb86bb39-96da-45d8-a394-fafc27fc2869', 'cf06becb-2988-4168-abc9-5c8faa542e69'],
+          },
+        },
+        entities: {
+          projects: {
+            '3e85d310-4ac5-444d-8465-de39767af6c7': {
+              id: '3e85d310-4ac5-444d-8465-de39767af6c7',
+            },
+            '816105f4-37a8-4ff5-819b-d9597df18128': {
+              id: '816105f4-37a8-4ff5-819b-d9597df18128',
+            },
+            'fb86bb39-96da-45d8-a394-fafc27fc2869': {
+              id: 'fb86bb39-96da-45d8-a394-fafc27fc2869',
+            },
+            'cf06becb-2988-4168-abc9-5c8faa542e69': {
+              id: 'cf06becb-2988-4168-abc9-5c8faa542e69',
+            },
+          },
+        },
+      };
+
+      const data = selectEntitiesFromQueryWithUpdateQueries(state, mainKey, updateQueries);
+
+      expect(data).toEqual([
+        {
+          id: '3e85d310-4ac5-444d-8465-de39767af6c7',
+        },
+        {
+          id: '816105f4-37a8-4ff5-819b-d9597df18128',
+        },
+        {
+          id: 'fb86bb39-96da-45d8-a394-fafc27fc2869',
+        },
+        {
+          id: 'cf06becb-2988-4168-abc9-5c8faa542e69',
         },
       ]);
     });

--- a/src/store/entities/memoizeWithResultArrayEntryShallowCheck.ts
+++ b/src/store/entities/memoizeWithResultArrayEntryShallowCheck.ts
@@ -3,7 +3,7 @@ const shallow = (previous: any, next: any) => {
 };
 
 const shallowOnArray = (previous: any, next: any) => {
-  if (Array.isArray(previous) && Array.isArray(next)) {
+  if (Array.isArray(previous) && Array.isArray(next) && previous.length === next.length) {
     return previous.every((item, index) => shallow(item, next[index]));
   }
 

--- a/src/store/queries/__tests__/selectors.spec.ts
+++ b/src/store/queries/__tests__/selectors.spec.ts
@@ -2,10 +2,11 @@ import {
   selectQueries,
   selectLoadingFromQueryFactory,
   selectMetaFromQueryFactory,
+  selectQueriesByKeys,
   selectQueryByKey,
-  selectLoadingFromQueryWithUpdateQueriesFactory,
   selectIdsFromQuery,
   selectDomainNameFromQuery,
+  selectLoadingFromQueriesFactory,
 } from '../selectors';
 import generateQueryCacheKey from '../../../utils/generateQueryCacheKey';
 
@@ -73,14 +74,6 @@ describe('queries selectors', () => {
     expect(meta).toEqual({ matches: 2 });
   });
 
-  it('selects the combined loading state of multiple queries', () => {
-    const selectLoadingFromQueryWithUpdateQueries = selectLoadingFromQueryWithUpdateQueriesFactory();
-
-    const loading = selectLoadingFromQueryWithUpdateQueries(INITIAL_STATE, 'uniqueKey', ['uniqueKey2']);
-
-    expect(loading).toBeTruthy();
-  });
-
   it('selects the ids from a query', () => {
     INITIAL_STATE.queries = {
       uniqueKey3: {
@@ -100,5 +93,39 @@ describe('queries selectors', () => {
 
     const domain = selectDomainNameFromQuery(INITIAL_STATE, key);
     expect(domain).toEqual('projects');
+  });
+
+  describe('selectQueriesByKeys', () => {
+    it('selects all queries using passed keys', () => {
+      const keys = ['key1', 'key2'];
+      INITIAL_STATE.queries = {
+        [keys[0]]: {
+          id: 'key1',
+        },
+        [keys[1]]: {
+          id: 'key2',
+        },
+      };
+
+      expect(selectQueriesByKeys(INITIAL_STATE, keys)).toEqual([{ id: 'key1' }, { id: 'key2' }]);
+    });
+  });
+
+  describe('selectLoadingFromQueriesFactory', () => {
+    const selectLoadingFromQueries = selectLoadingFromQueriesFactory();
+    it('selects the combined loading state of multiple queries', () => {
+      const keys = ['key1', 'key2'];
+      INITIAL_STATE.queries = {
+        [keys[0]]: {
+          loading: false,
+        },
+        [keys[1]]: {
+          loading: true,
+        },
+      };
+      const loading = selectLoadingFromQueries(INITIAL_STATE, keys);
+
+      expect(loading).toBeTruthy();
+    });
   });
 });

--- a/src/store/queries/__tests__/selectors.spec.ts
+++ b/src/store/queries/__tests__/selectors.spec.ts
@@ -7,6 +7,7 @@ import {
   selectIdsFromQuery,
   selectDomainNameFromQuery,
   selectLoadingFromQueriesFactory,
+  selectFollowUpQueries,
 } from '../selectors';
 import generateQueryCacheKey from '../../../utils/generateQueryCacheKey';
 
@@ -126,6 +127,35 @@ describe('queries selectors', () => {
       const loading = selectLoadingFromQueries(INITIAL_STATE, keys);
 
       expect(loading).toBeTruthy();
+    });
+  });
+
+  describe('selectFollowUpQueries', () => {
+    it('selects and builds a collection of follow up queries', () => {
+      const combine = ({ previousData, data }: { previousData: any; data: any }) => [...previousData, data];
+      const updateQueries = {
+        key1: combine,
+        key2: combine,
+      };
+      INITIAL_STATE.queries = {
+        key1: {
+          loading: false,
+          ids: ['id1', 'id2'],
+        },
+        key2: {
+          loading: true,
+        },
+      };
+
+      const followUpQueries = selectFollowUpQueries(INITIAL_STATE, null, updateQueries);
+      expect(followUpQueries).toEqual([
+        {
+          loading: false,
+          ids: ['id1', 'id2'],
+          updateQuery: combine,
+        },
+        { loading: true, updateQuery: combine },
+      ]);
     });
   });
 });

--- a/src/store/queries/reducer.ts
+++ b/src/store/queries/reducer.ts
@@ -4,15 +4,15 @@ import produce, { Draft } from 'immer';
 
 import * as actions from './actions';
 
-export type State = DeepReadonly<{
-  [key: string]: {
-    loading: boolean;
-    error?: Error;
-    ids?: string | string[];
-    data?: any;
-    meta?: any;
-  };
-}>;
+export type Query = {
+  loading: boolean;
+  error?: Error;
+  ids?: string | string[];
+  data?: any;
+  meta?: any;
+};
+
+export type State = DeepReadonly<Record<string, Query>>;
 
 export type QueryAction = ActionType<typeof actions>;
 

--- a/src/store/queries/selectors.ts
+++ b/src/store/queries/selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import { State } from '../reducer';
 import decodeQueryCacheKey from '../../utils/decodeQueryCacheKey';
+import { UpdateQueries } from '../../useQuery/useQuery';
 
 export const selectQueries = (state: State) => state.queries;
 
@@ -24,6 +25,16 @@ export const selectDomainNameFromQuery = createSelector(
 );
 
 export const selectDataFromQuery = createSelector(selectQueryByKey, (query) => query && query.data);
+
+export const selectFollowUpQueries = createSelector(
+  (_: any, __: any, updateQueries: UpdateQueries) => updateQueries,
+  selectQueries,
+  (updateQueries, queries) => {
+    return Object.keys(updateQueries).map((key) => {
+      return { ...queries[key], updateQuery: updateQueries[key] };
+    });
+  }
+);
 
 // Factories
 

--- a/src/store/queries/selectors.ts
+++ b/src/store/queries/selectors.ts
@@ -10,6 +10,12 @@ export const selectQueryByKey = createSelector(
   (queries, key) => queries[key]
 );
 
+export const selectQueriesByKeys = createSelector(
+  selectQueries,
+  (_, keys) => keys,
+  (queries, keys) => keys.map((key) => queries[key])
+);
+
 export const selectIdsFromQuery = createSelector(selectQueryByKey, (query) => query && query.ids);
 
 export const selectDomainNameFromQuery = createSelector(
@@ -26,13 +32,5 @@ export const selectLoadingFromQueryFactory = () =>
 
 export const selectMetaFromQueryFactory = () => createSelector(selectQueryByKey, (query) => query && query.meta);
 
-export const selectLoadingFromQueryWithUpdateQueriesFactory = () =>
-  createSelector(
-    (state: State) => state,
-    (_, key) => key,
-    (_, __, updateQueryKeys) => updateQueryKeys,
-    (state, key: string, updateQueryKeys: string[]) => {
-      const selectLoadingFromQuery = selectLoadingFromQueryFactory();
-      return [key, ...updateQueryKeys].some((nextKey) => selectLoadingFromQuery(state, nextKey));
-    }
-  );
+export const selectLoadingFromQueriesFactory = () =>
+  createSelector(selectQueriesByKeys, (queries) => queries.some((query) => query && query.loading));

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -78,9 +78,6 @@ const useQuery: (query: Query, variables?: any, options?: Options) => any = (
   // @TODO refactor this so it works with our new redux flow
   const fetchMore = useCallback(
     ({ variables: newVariables, updateQuery }) => {
-      if (!ignoreCache && data) {
-        return;
-      }
       dispatch(queryRequest({ key: generateQueryCacheKey(query(newVariables)), APIContext: API }));
     },
     [key, ignoreCache, data]

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -6,6 +6,10 @@ import { queryRequest } from '../store/queries/actions';
 import { useSelector, useDispatch } from '../store/CustomReduxContext';
 import Context from '../Context';
 import {
+  selectEntitiesFromQueryWithUpdateQueriesFactory,
+  selectEntitiesFromQueryFactory,
+} from '../store/entities/selectors';
+import {
   selectLoadingFromQueryFactory,
   selectMetaFromQueryFactory,
   selectLoadingFromQueriesFactory,
@@ -44,7 +48,7 @@ const registerQuery = (query: { fetch: () => void } | undefined, fetch: () => vo
   };
 };
 
-type UpdateQueries = Record<string, (data: { previousData: any; data: any }) => any>;
+export type UpdateQueries = Record<string, (data: { previousData: any; data: any }) => any>;
 
 const defaultConfig = {
   ignoreCache: false,
@@ -64,12 +68,17 @@ const useQuery: (query: Query, variables?: any, options?: Options) => any = (
   const selectLoading = useMemo(selectLoadingFromQueryFactory, []);
   const selectLoadingFromQueries = useMemo(selectLoadingFromQueriesFactory, []);
   const selectData = useMemo(selectEntitiesFromQueryFactory, []);
+  const selectDataWithUpdateQueries = useMemo(selectEntitiesFromQueryWithUpdateQueriesFactory, []);
   const selectMeta = useMemo(selectMetaFromQueryFactory, []);
   const dispatch = useDispatch();
 
   const loading = useSelector((state: State) =>
     hasUpdateQueries ? selectLoadingFromQueries(state, [key, ...Object.keys(updateQueries)]) : selectLoading(state, key)
   );
+  const data = useSelector((state) =>
+    hasUpdateQueries ? selectDataWithUpdateQueries(state, key, updateQueries) : selectData(state, key)
+  );
+
   const meta = useSelector((state: State) => selectMeta(state, key));
 
   // Effect only runs when the result query (with variables) has changed

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -5,8 +5,11 @@ import generateQueryCacheKey from '../utils/generateQueryCacheKey';
 import { queryRequest } from '../store/queries/actions';
 import { useSelector, useDispatch } from '../store/CustomReduxContext';
 import Context from '../Context';
-import { selectEntitiesFromQueryFactory } from '../store/entities/selectors';
-import { selectLoadingFromQueryFactory, selectMetaFromQueryFactory } from '../store/queries/selectors';
+import {
+  selectLoadingFromQueryFactory,
+  selectMetaFromQueryFactory,
+  selectLoadingFromQueriesFactory,
+} from '../store/queries/selectors';
 import { State } from 'store/reducer';
 
 type CalculatedQuery = {
@@ -55,15 +58,18 @@ const useQuery: (query: Query, variables?: any, options?: Options) => any = (
 ) => {
   const key = useMemo(() => generateQueryCacheKey(query(variables)), [variables]);
   const [updateQueries, setUpdateQueries] = useState<UpdateQueries>({});
+  const hasUpdateQueries = Object.keys(updateQueries).length !== 0;
 
   const API = useContext(Context);
   const selectLoading = useMemo(selectLoadingFromQueryFactory, []);
+  const selectLoadingFromQueries = useMemo(selectLoadingFromQueriesFactory, []);
   const selectData = useMemo(selectEntitiesFromQueryFactory, []);
   const selectMeta = useMemo(selectMetaFromQueryFactory, []);
   const dispatch = useDispatch();
 
-  const loading = useSelector((state: State) => selectLoading(state, key));
-  const data = useSelector((state) => selectData(state, key));
+  const loading = useSelector((state: State) =>
+    hasUpdateQueries ? selectLoadingFromQueries(state, [key, ...Object.keys(updateQueries)]) : selectLoading(state, key)
+  );
   const meta = useSelector((state: State) => selectMeta(state, key));
 
   // Effect only runs when the result query (with variables) has changed

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -93,7 +93,6 @@ const useQuery: (query: Query, variables?: any, options?: Options) => any = (
   // Function supplied to do a refetch with new variables
   // Takes an updateQuery variable that allows you to specify how
   // The data should be merged
-  // @TODO refactor this so it works with our new redux flow
   const fetchMore = useCallback(
     ({ variables: newVariables, updateQuery }) => {
       const fetchMoreKey = generateQueryCacheKey(query(newVariables));


### PR DESCRIPTION
### Added

* Re-introduced a working version of the `fetchMore` function call

It's not an ideal solution, as I'm noticing some selectors are not getting memoized correctly and are re-run when state changes, but re-renders should generally be prevented.