### PR TITLE
Feature: introduce fetchAll query option

### DIFF
--- a/src/store/fetcher.ts
+++ b/src/store/fetcher.ts
@@ -15,12 +15,12 @@ const fetcher = ({ dispatch }) => (next) => ({ type, payload }: { type: string; 
   switch (type) {
     case getType(queryActions.queryRequest): {
       const key = payload.key;
-      const { domain, action, options } = decodeQueryCacheKey(key);
+      const { domain, action, options, fetchAll } = decodeQueryCacheKey(key);
 
       const isEntityAction = action === 'info' || action === 'list';
 
       // @TODO this promise should be cancellable
-      payload.APIContext[domain][action](options)
+      payload.APIContext[domain][action](options, { fetchAll: Boolean(fetchAll) })
         .then((response: Response) => {
           if (!isEntityAction) {
             Object.keys(response.included || {}).forEach((entityType) => {

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -52,13 +52,12 @@ export type UpdateQueries = Record<string, (data: { previousData: any; data: any
 
 const defaultConfig = {
   ignoreCache: false,
-  fetchAll: false,
 };
 
 const useQuery: (query: Query, variables?: any, options?: Options) => any = (
   query,
   variables,
-  { ignoreCache = defaultConfig.ignoreCache, fetchAll = defaultConfig.fetchAll }: Options = defaultConfig
+  { ignoreCache = defaultConfig.ignoreCache }: Options = defaultConfig
 ) => {
   const key = useMemo(() => generateQueryCacheKey(query(variables)), [variables]);
   const [updateQueries, setUpdateQueries] = useState<UpdateQueries>({});


### PR DESCRIPTION
### Added

* `fetchAll: true` can be added to the returned result of a query in order to make use of the `@teamleader/sdk-js` option that will continue making requests based on pagination