### PR TITLE
Fix: data should initially be undefined

### DIFF
--- a/src/store/entities/__tests__/selectors.spec.ts
+++ b/src/store/entities/__tests__/selectors.spec.ts
@@ -6,6 +6,7 @@ import {
   selectEntityByDomainAndIdFactory,
   selectEntitiesByDomainAndIdsFactory,
   selectEntitiesFromQueryWithUpdateQueriesFactory,
+  mapQueryToData,
 } from '../selectors';
 import generateQueryCacheKey from '../../../utils/generateQueryCacheKey';
 
@@ -232,6 +233,45 @@ describe('Entities selectors', () => {
         {
           id: 'cf06becb-2988-4168-abc9-5c8faa542e69',
         },
+      ]);
+    });
+  });
+
+  describe('mapQueryToData', () => {
+    it('returns undefined when the query is undefined', () => {
+      const data = mapQueryToData(undefined, {});
+      expect(data).toBeUndefined();
+    });
+
+    it('returns the data from a query if there is any', () => {
+      const data = mapQueryToData({ data: 'test' }, {});
+      expect(data).toEqual('test');
+    });
+
+    it('returns undefined when there are no ids on the query yet', () => {
+      const data = mapQueryToData({ loading: true }, {});
+      expect(data).toBeUndefined();
+    });
+
+    it('returns single entities or arrays of entities when available', () => {
+      const singleEntity = mapQueryToData(
+        { ids: '803d0b7e-4ab0-496e-bec6-d7e1cf5c1ba1' },
+        { '803d0b7e-4ab0-496e-bec6-d7e1cf5c1ba1': { id: '803d0b7e-4ab0-496e-bec6-d7e1cf5c1ba1' } }
+      );
+
+      expect(singleEntity).toEqual({ id: '803d0b7e-4ab0-496e-bec6-d7e1cf5c1ba1' });
+
+      const entityCollection = mapQueryToData(
+        { ids: ['803d0b7e-4ab0-496e-bec6-d7e1cf5c1ba1', '324d6d7a-3793-497a-be10-dcac78ee2468'] },
+        {
+          '803d0b7e-4ab0-496e-bec6-d7e1cf5c1ba1': { id: '803d0b7e-4ab0-496e-bec6-d7e1cf5c1ba1' },
+          '324d6d7a-3793-497a-be10-dcac78ee2468': { id: '324d6d7a-3793-497a-be10-dcac78ee2468' },
+        }
+      );
+
+      expect(entityCollection).toEqual([
+        { id: '803d0b7e-4ab0-496e-bec6-d7e1cf5c1ba1' },
+        { id: '324d6d7a-3793-497a-be10-dcac78ee2468' },
       ]);
     });
   });

--- a/src/store/entities/selectors.ts
+++ b/src/store/entities/selectors.ts
@@ -31,7 +31,7 @@ export const selectDomainFromQuery = createSelector(
 
 export const mapQueryToData = (query: Partial<Query> | undefined, domain: NormalizedEntities) => {
   if (!query) {
-    return null;
+    return;
   }
 
   if (query.data) {
@@ -39,7 +39,7 @@ export const mapQueryToData = (query: Partial<Query> | undefined, domain: Normal
   }
 
   if (!query.ids) {
-    return null;
+    return;
   }
 
   if (Array.isArray(query.ids)) {

--- a/src/store/entities/selectors.ts
+++ b/src/store/entities/selectors.ts
@@ -29,7 +29,7 @@ export const selectDomainFromQuery = createSelector(
   (domainName, entities) => entities[domainName]
 );
 
-const mapQueryDataToEntity = (query: Partial<Query> | null, domain: NormalizedEntities) => {
+export const mapQueryToData = (query: Partial<Query> | undefined, domain: NormalizedEntities) => {
   if (!query) {
     return null;
   }
@@ -56,7 +56,7 @@ export const selectEntitiesFromQueryFactory = () =>
     selectDataFromQuery,
     selectIdsFromQuery,
     selectDomainFromQuery,
-    (queryData, ids, domain) => mapQueryDataToEntity({ data: queryData, ids }, domain)
+    (queryData, ids, domain) => mapQueryToData({ data: queryData, ids }, domain)
   );
 
 export const selectEntityByDomainAndIdFactory = () =>
@@ -84,15 +84,15 @@ export const selectEntitiesFromQueryWithUpdateQueriesFactory = () =>
     selectQueryByKey,
     selectFollowUpQueries,
     selectDomainFromQuery,
-    (mainQuery: Query | null, followUpQueries: FollowUpQuery[], domain: NormalizedEntities) => {
-      let mainQueryData = mapQueryDataToEntity(mainQuery, domain);
+    (mainQuery: Query | undefined, followUpQueries: FollowUpQuery[], domain: NormalizedEntities) => {
+      let mainQueryData = mapQueryToData(mainQuery, domain);
 
       if (!mainQueryData) {
         return mainQueryData;
       }
 
       followUpQueries.some((query) => {
-        const nextQueryData = mapQueryDataToEntity(query, domain);
+        const nextQueryData = mapQueryToData(query, domain);
 
         if (!nextQueryData) {
           return true;

--- a/src/useQuery/useQuery.spec.tsx
+++ b/src/useQuery/useQuery.spec.tsx
@@ -108,7 +108,7 @@ describe('useQuery', () => {
     });
 
     expect(result.current.loading).toEqual(true);
-    expect(result.current.data).toBeNull();
+    expect(result.current.data).toBeUndefined();
     expect(result.current.error).toBeUndefined();
     expect(result.current.fetchMore).toBeInstanceOf(Function);
   });


### PR DESCRIPTION
### Fixed

* The `data` property was returning `null` instead of `undefined` when a query was still loading, this wasn't previously the case so this change has been reverted.