### PR TITLE
Fetch policy: cache-first, cache-and-network and network-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Added
+
+* Fetch policy: cache-first, cache-and-network and network-only  ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#317](https://github.com/teamleadercrm/react-hooks-api/pull/317))
+
 ## [0.1.0-rc13] - 2020-04-13
 
 ### 🐛 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,19 @@
 
 ### Added
 
-* Fetch policy: cache-first, cache-and-network and network-only  ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#317](https://github.com/teamleadercrm/react-hooks-api/pull/317))
+- Fetch policy: cache-first, cache-and-network and network-only ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#317](https://github.com/teamleadercrm/react-hooks-api/pull/317))
 
 ## [0.1.0-rc13] - 2020-04-13
 
 ### 🐛 Fixed
 
-* Fixed an issue with the global queries object which caused a memory leak that would duplicate network requests ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#314](https://github.com/teamleadercrm/react-hooks-api/pull/314))
+- Fixed an issue with the global queries object which caused a memory leak that would duplicate network requests ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#314](https://github.com/teamleadercrm/react-hooks-api/pull/314))
 
 ## [0.1.0-rc12] - 04-03-2020
 
 ### 🐛 Fixed
 
-* Fix a bug when automatically merging side-loaded entities causing problems with unconventional paths ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#245](https://github.com/teamleadercrm/react-hooks-api/pull/245))
+- Fix a bug when automatically merging side-loaded entities causing problems with unconventional paths ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#245](https://github.com/teamleadercrm/react-hooks-api/pull/245))
 
 ## [0.1.0-rc11] - 2020-01-29
 
@@ -24,77 +24,77 @@ This version is a republish of a version 0.1.0-rc10 because the wrong version wa
 
 ### 🐛 Fixed
 
-* Fix error when resolving primitive values ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#207](https://github.com/teamleadercrm/react-hooks-api/pull/207))
+- Fix error when resolving primitive values ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#207](https://github.com/teamleadercrm/react-hooks-api/pull/207))
 
 ## [0.1.0-rc9] - 2020-01-28
 
 ### 🐛 Fixed
 
-* Fix error when trying to merge array references that can be `null` ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#204](https://github.com/teamleadercrm/react-hooks-api/pull/204))
+- Fix error when trying to merge array references that can be `null` ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#204](https://github.com/teamleadercrm/react-hooks-api/pull/204))
 
 ## [0.1.0-rc8] - 2020-01-23
 
 ### 🐛 Fixed
 
-* Fix error when trying to merge entity types that were not present in the store ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#196](https://github.com/teamleadercrm/react-hooks-api/pull/196))
+- Fix error when trying to merge entity types that were not present in the store ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#196](https://github.com/teamleadercrm/react-hooks-api/pull/196))
 
 ### ♻️ Changed
 
-* [INTERNAL] Replace deprecated tslint with eslint ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#194](https://github.com/teamleadercrm/react-hooks-api/pull/194))
+- [INTERNAL] Replace deprecated tslint with eslint ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#194](https://github.com/teamleadercrm/react-hooks-api/pull/194))
 
 ## [0.1.0-rc7] - 2020-01-13
 
 ### ✨Added
 
-* Support `fetchAll` option from `@teamleader/api` ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#183](https://github.com/teamleadercrm/react-hooks-api/pull/183))
-
+- Support `fetchAll` option from `@teamleader/api` ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#183](https://github.com/teamleadercrm/react-hooks-api/pull/183))
 
 ## [0.1.0-rc6] - 2020-01-09
 
 ### 🐛 Fixed
 
-* 🐛 Fix fetch call being overwritten when 2 identical queries get registered https://github.com/teamleadercrm/react-hooks-api/pull/180
+- 🐛 Fix fetch call being overwritten when 2 identical queries get registered https://github.com/teamleadercrm/react-hooks-api/pull/180
 
 ## [0.1.0-rc5] - 2020-01-07
 
 ### 🐛 Fixed
 
-* Typing for the exported queries object
+- Typing for the exported queries object
 
 ## [0.1.0-rc4] - 2020-01-07
 
 ### ✨Added
 
-* Implement global queries object https://github.com/teamleadercrm/react-hooks-api/pull/178
+- Implement global queries object https://github.com/teamleadercrm/react-hooks-api/pull/178
 
 ## [0.1.0-rc3] - 2019-12-02
 
 ### 🐛 Fixed
 
-* Fixed a bug where we were trying to select ids of a query before it has finished loading https://github.com/teamleadercrm/react-hooks-api/pull/153
+- Fixed a bug where we were trying to select ids of a query before it has finished loading https://github.com/teamleadercrm/react-hooks-api/pull/153
 
 ## [0.1.0-rc2] - 2019-12-02
 
 ### 🐛 Fixed
 
-* Fixed a bug that caused entities to be overwritten instead of enriched
+- Fixed a bug that caused entities to be overwritten instead of enriched
 
 ## [0.1.0-rc1] - 2019-11-29
 
 ### 💥Breaking changes
 
 - Sideloaded data is now automatically merged into the entity it belongs to. This means the signature of the object returned by useQuery has changed. See below or consult the README for more information.
- ```ts
+
+```ts
 type Object = {
-  // The entity or list of entities
-  // Can also be calculated data (see projectItems.report)
-  data: Entity || Array<Entity> || NonEntity;
-  // Metadata returned by the request
-  meta: any
+ // The entity or list of entities
+ // Can also be calculated data (see projectItems.report)
+ data: Entity || Array<Entity> || NonEntity;
+ // Metadata returned by the request
+ meta: any
 }
 
 const object: Object = useQuery(query);
- ```
+```
 
 ## [0.0.4] - 2019-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-### Added
+### ✨ Added
 
 - Fetch policy: cache-first, cache-and-network and network-only ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#317](https://github.com/teamleadercrm/react-hooks-api/pull/317))
 

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -21,23 +21,31 @@ type CalculatedQuery = {
 
 type Query = (variables?: any) => CalculatedQuery;
 
+type FetchPolicy = 'cache-first' | 'cache-and-network' | 'network-only';
+
 type Options = {
   ignoreCache?: boolean;
   fetchAll?: boolean;
+  fetchPolicy: FetchPolicy;
 };
 
 export const queries: Record<string, { fetch: () => void; _linkedQueriesFetches: Record<string, () => void> }> = {};
 let uniqueHookIndex = 0;
 
-const defaultConfig = {
+const defaultConfig: Options = {
   ignoreCache: false,
   fetchAll: false,
+  fetchPolicy: 'cache-first',
 };
 
 const useQuery: (query: Query, variables?: any, options?: Options) => any = (
   query,
   variables,
-  { ignoreCache = defaultConfig.ignoreCache, fetchAll = defaultConfig.fetchAll } = defaultConfig,
+  {
+    ignoreCache = defaultConfig.ignoreCache,
+    fetchAll = defaultConfig.fetchAll,
+    fetchPolicy = defaultConfig.fetchPolicy,
+  } = defaultConfig,
 ) => {
   const uniqueId = useMemo(() => {
     const localIndex = uniqueHookIndex;

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -47,6 +47,11 @@ const useQuery: (query: Query, variables?: any, options?: Options) => any = (
     fetchPolicy = defaultConfig.fetchPolicy,
   } = defaultConfig,
 ) => {
+  // Backwards compatibility for the deprecated ignoreCache option
+  if (ignoreCache) {
+    fetchPolicy = 'network-only';
+  }
+
   const uniqueId = useMemo(() => {
     const localIndex = uniqueHookIndex;
     uniqueHookIndex++;

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -29,23 +29,6 @@ type Options = {
 export const queries: Record<string, { fetch: () => void; _linkedQueriesFetches: Record<string, () => void> }> = {};
 let uniqueHookIndex = 0;
 
-const registerQuery = (query: { fetch: () => void } | undefined, fetch: () => void) => {
-  // A previous query has already been registered, hook up its fetch call as well
-  // @TODO once every query relies on the same redux state object, this can be removed
-  if (query) {
-    return {
-      fetch: () => {
-        query.fetch();
-        fetch();
-      },
-    };
-  }
-
-  return {
-    fetch,
-  };
-};
-
 const defaultConfig = {
   ignoreCache: false,
   fetchAll: false,
@@ -175,7 +158,7 @@ const useQuery: (query: Query, variables?: any, options?: Options) => any = (
     } else {
       queries[queryKey] = {
         fetch: (): void => {
-          Object.values(queries[queryKey]?._linkedQueriesFetches || []).forEach(fetch => fetch());
+          Object.values(queries[queryKey]?._linkedQueriesFetches || []).forEach((fetch) => fetch());
         },
         _linkedQueriesFetches: {
           ...queries[queryKey]?._linkedQueriesFetches,

--- a/src/useQuery/useQuery.ts
+++ b/src/useQuery/useQuery.ts
@@ -26,7 +26,7 @@ type FetchPolicy = 'cache-first' | 'cache-and-network' | 'network-only';
 type Options = {
   ignoreCache?: boolean;
   fetchAll?: boolean;
-  fetchPolicy: FetchPolicy;
+  fetchPolicy?: FetchPolicy;
 };
 
 export const queries: Record<string, { fetch: () => void; _linkedQueriesFetches: Record<string, () => void> }> = {};
@@ -96,8 +96,7 @@ const useQuery: (query: Query, variables?: any, options?: Options) => any = (
         case 'cache-first':
           {
             // Check for previous results
-            const cacheResult = selectQuery(store.getState(), key);
-            if (cacheResult) {
+            if (key !== queryKey && selectQuery(store.getState(), key)) {
               const data = selectMergedEntities(store.getState(), { key });
               const meta = selectMetaFromQuery(store.getState(), key);
 
@@ -110,8 +109,7 @@ const useQuery: (query: Query, variables?: any, options?: Options) => any = (
         case 'cache-and-network':
           {
             // Check for previous results
-            const cacheResult = selectQuery(store.getState(), key);
-            if (cacheResult) {
+            if (key !== queryKey && selectQuery(store.getState(), key)) {
               const data = selectMergedEntities(store.getState(), { key });
               const meta = selectMetaFromQuery(store.getState(), key);
               setState({ loading: false, data, meta, error: undefined });


### PR DESCRIPTION
### Added

* A new option: `fetchPolicy`
  * `cache-first`: will look at the cache and return the cached value or send a request
  * `cache-and-network`: returns cached data immediately, but also sends a request to refresh it
  * `network-only` (previously `ignoreCache = true`): ignores the cache and always sends network requests

The default value is `cache-first` unless `ignoreCache` is set to `true`, in which case `fetchPolicy` will default to `network-only`