### PR TITLE
[CHORE] Use latest teamleader api version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@teamleader/react-hooks-api",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@teamleader/react-hooks-api",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "devDependencies": {
-        "@teamleader/api": "^3.4.0",
+        "@teamleader/api": "^4.1.0",
         "@testing-library/react-hooks": "^1.1.0",
         "@types/jest": "^26.0.20",
         "@types/react": "^16.8.18",
@@ -29,11 +29,11 @@
         "tslint": "^5.16.0",
         "tslint-config-prettier": "^1.18.0",
         "typesafe-actions": "^4.4.0",
-        "typescript": "^3.4.5",
+        "typescript": "^3.9.7",
         "utility-types": "^3.7.0"
       },
       "peerDependencies": {
-        "@teamleader/api": "^3.4.0",
+        "@teamleader/api": "^4.1.0",
         "react": "^16.8.6",
         "react-dom": "^16.8.6",
         "react-redux": "^7.0.0",
@@ -840,7 +840,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -1255,9 +1254,9 @@
       }
     },
     "node_modules/@teamleader/api": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@teamleader/api/-/api-3.5.0.tgz",
-      "integrity": "sha512-yjvIX06u2TMmr6JnTwhu9IGe2fLvaJBvcv7zMDTiNVvElsQovSoHNyB2Hhtfjtykdm7YW9KznrrfoJw5fa/J6A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@teamleader/api/-/api-4.1.0.tgz",
+      "integrity": "sha512-rASL7HY5Lw4MGlyp2Znp2fJl1gOG1chNJb/NEzTKMJRB+IsFewNPqzFIKhO/66883ofCyi0S94MGt0ZYVeoGhg==",
       "dev": true,
       "dependencies": {
         "humps": "^2.0.1",
@@ -2505,8 +2504,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -4195,7 +4193,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -9342,9 +9339,9 @@
       }
     },
     "@teamleader/api": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@teamleader/api/-/api-3.5.0.tgz",
-      "integrity": "sha512-yjvIX06u2TMmr6JnTwhu9IGe2fLvaJBvcv7zMDTiNVvElsQovSoHNyB2Hhtfjtykdm7YW9KznrrfoJw5fa/J6A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@teamleader/api/-/api-4.1.0.tgz",
+      "integrity": "sha512-rASL7HY5Lw4MGlyp2Znp2fJl1gOG1chNJb/NEzTKMJRB+IsFewNPqzFIKhO/66883ofCyi0S94MGt0ZYVeoGhg==",
       "dev": true,
       "requires": {
         "humps": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/react-hooks-api",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "React hooks for the Teamleader API",
   "main": "./lib/bundle.cjs.js",
   "module": "./lib/bundle.esm.js",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/teamleadercrm/react-hooks-api#readme",
   "devDependencies": {
-    "@teamleader/api": "^3.4.0",
+    "@teamleader/api": "^4.1.0",
     "@testing-library/react-hooks": "^1.1.0",
     "@types/jest": "^26.0.20",
     "@types/react": "^16.8.18",
@@ -53,7 +53,7 @@
     "utility-types": "^3.7.0"
   },
   "peerDependencies": {
-    "@teamleader/api": "^3.4.0",
+    "@teamleader/api": "^4.1.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-redux": "^7.0.0",


### PR DESCRIPTION
I have updated the @teamleader/api version in core. But yarn gives a warning that there is an incorrect peer dependency for this library. So I figured I might as well update the peerDependency and devDependency here so that both projects use the same/latest version.